### PR TITLE
footerのレンダリングをhomeページのみに制限する

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,6 @@
       <%= render 'shared/flash_messages' %>
       <%= yield %>
     </main>
-    <%= render 'shared/footer' %>
+    <%= render 'shared/footer' if current_page?(root_path) || current_page?(home_index_path) %>
   </body>
 </html>


### PR DESCRIPTION
## Issue または変更目的
close #38 

## 変更内容
- [x] footerのレンダリングをhomeページのみに制限する。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
- [x] ルートパスと`/home`のみで、footerが表示されることを確認する。
