### PR TITLE
タイムゾーンを日本に設定する

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Myapp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.i18n.default_locale = :ja


### PR DESCRIPTION
## Issue または変更目的
close #42 

## 変更内容
- [x] `config.time_zone = 'Tokyo'`と設定。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
- [x] rails consoleにて、Time.currentの結果がJST（日本標準時）で表示されていることを確認する。
