### PR TITLE
countによる余分なクエリを削除する

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -4,7 +4,7 @@
     <%= link_to "New", new_project_path, class: "btn btn-primary me-2" %>
     <%= link_to "完了", projects_done_index_path, class: "btn btn-outline-secondary" %>
   </div>
-  <div><%= @undone_projects.count %>件のプロジェクトを表示中</div>
+  <div><%= @undone_projects.length %>件のプロジェクトを表示中</div>
   <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3 py-3">
     <% @undone_projects.each do |project| %>
       <div class="col">


### PR DESCRIPTION
## Issue または変更目的
close #44 

## 変更内容
- [x] `count`を`length`に変更。

## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
- [x] `/pojects`にアクセスした際のログにおいて、Projectの取得が1度のみで、countのクエリが発生していないことを確認する。
