### PR TITLE
プロジェクトメンバー登録機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_undone_projects, if: :user_signed_in?
+  before_action :set_my_undone_projects, if: :user_signed_in?
 
   protected
 
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def set_undone_projects
-    @undone_projects = Project.undone.descend_by_updated_at
+  def set_my_undone_projects
+    @my_undone_projects = current_user.projects.undone.descend_by_updated_at
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   def index
+    @undone_projects = Project.undone.descend_by_updated_at.includes(:users).order("users.name ASC")
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,7 +8,9 @@ class ProjectsController < ApplicationController
   end
 
   def create
-    @project = Project.new(params.require(:project).permit(:name, :description, :is_done))
+    @project = Project.new(
+      **params.require(:project).permit(:name, :description, :is_done), users: [current_user]
+    )
     if @project.save
       flash[:notice] = 'プロジェクトを作成しました。'
       redirect_to projects_path

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,7 @@
 class Project < ApplicationRecord
+  has_many :project_members, dependent: :destroy
+  has_many :users, through: :project_members
+
   validates :name, presence: true
   validates :is_done, inclusion: [true, false]
 

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -1,0 +1,6 @@
+class ProjectMember < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  validates :project_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :project_members, dependent: :destroy
+  has_many :projects, through: :project_members
+
   validates :name, presence: true
 
   # Include default devise modules. Others available are:

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,7 +11,12 @@
         <div class="card h-100 shadow-sm">
           <div class="card-body d-flex flex-column">
             <h5 class="card-title mb-3"><%= project.name %></h5>
-            <p class="card-text mb-2">メンバー：</p>
+            <p class="card-text mb-2">メンバー：
+              <% project.users.each_with_index do |user, i| %>
+                <%= "、" if !i.zero? %>
+                <%= user.name %>
+              <% end %>
+            </p>
             <p class="card-text text-muted text-truncate"><%= project.description %></p>
             <div class="btn-group mt-auto align-self-start">
               <%= link_to "詳細", "#", class: "btn btn-sm btn-outline-secondary" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,9 +15,9 @@
                 <li class="nav-item mb-4">
                   <%= link_to "プロジェクト一覧", projects_path, class: "text-decoration-none text-light" %>
                 </li>
-                <li class="nav-item"><span class="fw-bold">プロジェクト</span>
+                <li class="nav-item"><span class="fw-bold">マイプロジェクト</span>
                   <ul class="py-2">
-                    <% @undone_projects.each do |project| %>
+                    <% @my_undone_projects.each do |project| %>
                       <li class="py-1">
                         <%= link_to project.name, "#", class: "text-decoration-none text-light" %>
                       </li>

--- a/db/migrate/20230522073030_create_project_members.rb
+++ b/db/migrate/20230522073030_create_project_members.rb
@@ -1,0 +1,12 @@
+class CreateProjectMembers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :project_members do |t|
+      t.integer :project_id
+      t.integer :user_id
+
+      t.timestamps
+    end
+
+    add_index :project_members, %i(project_id user_id), unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_08_101655) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_073030) do
+  create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "user_id"], name: "index_project_members_on_project_id_and_user_id", unique: true
+  end
+
   create_table "projects", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -20,11 +20,14 @@ RSpec.describe 'Projects', type: :system do
   end
 
   describe 'ヘッダー' do
-    let!(:undone_project) { create(:project, is_done: false) }
+    let(:undone_project) { create(:project, is_done: false) }
 
-    before { visit projects_path }
+    before do
+      undone_project.users << user
+      visit projects_path
+    end
 
-    it 'プロジェクト名が表示されていること' do
+    it '自分が割り当てられた未完了プロジェクト名が表示されていること' do
       within '.offcanvas' do
         expect(page).to have_content undone_project.name
       end
@@ -32,14 +35,18 @@ RSpec.describe 'Projects', type: :system do
   end
 
   describe 'プロジェクト一覧ページ' do
-    let!(:undone_project) { create(:project, is_done: false) }
+    let(:undone_project) { create(:project, is_done: false) }
 
-    before { visit projects_path }
+    before do
+      undone_project.users << user
+      visit projects_path
+    end
 
-    it 'プロジェクトの情報が表示されていること' do
-      within 'main' do
+    it '未完了プロジェクトの情報が表示されていること' do
+      within '.card' do
         expect(page).to have_content undone_project.name
         expect(page).to have_content undone_project.description
+        expect(page).to have_content user.name
       end
     end
   end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Projects', type: :system do
 
       expect(current_path).to eq projects_path
       expect(page).to have_content 'プロジェクトを作成しました。'
+      expect(Project.last.users).to eq [user]
     end
   end
 


### PR DESCRIPTION
## Issue または変更目的
close #40 

## 変更内容
- [x] プロジェクトメンバーモデルを作成する。
- [x] プロジェクト作成時に、作成したユーザーをプロジェクトにアサインする。
- [x] プロジェクト一覧
   - [x] navbar offcanvasには、自分が割り当てられたもののみ表示する。
      ![スクリーンショット 2023-06-12 18 58 57](https://github.com/musashi-634/task_app/assets/115614313/da2349ae-2878-4b48-a7db-7a2bf82c490b)

   - [x] プロジェクト一覧ページでは、各プロジェクトのメンバーを表示する。
      ![スクリーンショット 2023-06-12 18 57 18](https://github.com/musashi-634/task_app/assets/115614313/207c5910-3b85-42fb-8948-527af7edf30f)


## 確認手順
<!--仕様やテストがあるならその旨を記載すれば十分-->
テストを参照のこと。